### PR TITLE
Fixing the redirection in case the slug is in slugs, but is not the head

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,8 +20,8 @@ class ApplicationController < ActionController::Base
       render inline: "Document not found", status: :not_found
     elsif slug == @document.slug
       @document
-    elsif document.slugs.contains(slug)
-      redirect_to document_application_path(id, slug), status: :moved_permanently
+    elsif @document.slugs.include?(slug)
+      redirect_to document_path(id, @document.slug), status: :moved_permanently
     else
       render inline: "Document not found", status: :not_found
     end


### PR DESCRIPTION
For some reason, this didn't work in the starter kit.

Example: `/document/UkL0gMuvzYUANCpV/coconut-macaron` should redirect towards `/document/UkL0gMuvzYUANCpV/cool-coconut-macaron`, because for this document, `doc.slugs` equals `["cool-coconut-macaron","coconut-macaron"]`.

I'm sending this as a PR because I have a question, which could lead to an even better way to do it: since we're advocating it as the proper way to write URLs for all cases, shouldn't we make it a method in `PrismicService`, for reusability?
