### PR TITLE
Dealing with expired token

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,7 +76,14 @@ class ApplicationController < ActionController::Base
 
   def api
     @access_token = session['ACCESS_TOKEN']
-    @api ||= PrismicService.init_api(@access_token)
+    begin
+      @api ||= PrismicService.init_api(@access_token)
+    rescue Prismic::API::PrismicWSConnectionError
+      # In case there is a connection error, it could come from an expired token,
+      # so let's try it again after discarding the access token
+      session['ACCESS_TOKEN'] = @access_token = nil
+      @api ||= PrismicService.init_api(@access_token)
+    end
   end
 
 end


### PR DESCRIPTION
When a token comes back expired, rather than generating a 500, this tries the API connection again after discarding the token.

I'm still pull-requesting this because I could use an outside opinion on this. :)
