### PR TITLE
Writing link_resolver(@maybe_ref) faster in views

### DIFF
--- a/app/helpers/prismic_helper.rb
+++ b/app/helpers/prismic_helper.rb
@@ -15,6 +15,11 @@ module PrismicHelper
     }
   end
 
+  # Allows for a faster way to write link_resolver in the views.
+  def lr
+    link_resolver(@maybe_ref)
+  end
+
   # Checks if the user is connected to prismic.io's OAuth2.
   def connected?
     !!@access_token

--- a/app/views/application/document.html.erb
+++ b/app/views/application/document.html.erb
@@ -3,5 +3,5 @@
 		as_html_safe is a monkey-patch in your prismicio_custom.rb, just because it's faster than typing
 		@document.as_html(link_resolver(@maybe_ref)).html_safe
 	%>
-	<%= @document.as_html_safe(link_resolver(@maybe_ref)) %>
+	<%= @document.as_html_safe(lr) %>
 </article>

--- a/app/views/application/index.html.erb
+++ b/app/views/application/index.html.erb
@@ -20,7 +20,7 @@
 <ul>
   <% @documents.each do |doc| %>
     <li>
-      <%= link_to doc.slug, link_resolver(@maybe_ref).link_to(doc) %>
+      <%= link_to doc.slug, lr.link_to(doc) %>
       <%#
         We could have written document_path(id: doc.id, slug: doc.slug, ref: maybe_ref);
         but it's better to use the link_resolver, as it allows you to maintain in one place

--- a/app/views/application/search.html.erb
+++ b/app/views/application/search.html.erb
@@ -12,7 +12,7 @@
 <ul>
   <% @documents.each do |doc| %>
     <li>
-      <%= link_to doc.slug, link_resolver(@maybe_ref).link_to(doc) %>
+      <%= link_to doc.slug, lr.link_to(doc) %>
       <%#
         We could have written document_path(id: doc.id, slug: doc.slug, ref: maybe_ref);
         but it's better to use the link_resolver, as it allows you to maintain in one place


### PR DESCRIPTION
Each time we use `as_html` in views (which is often), we write it like this: `as_html(link_resolver(@maybe_ref))`. 99% of the time, it is the same link_resolver, and the same @maybe_ref (actually, I can't see of any non-borderline case where it wouldn't be the case).

This allows to do `as_html(lr)`.

I'm not sure it's a good idea, that's a lot of information lost in this way to write it; what do you think?
