### PR TITLE
Setting the prismic.io OAuth actions in their own controller

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,44 +29,7 @@ class ApplicationController < ActionController::Base
                     .query(%([[:d = fulltext(document, "#{params[:q]}")]]))
                     .submit(@ref)
   end
-
-
-  # Actions for the OAuth2 pages (signin, signout, ...)
-
-  def get_callback_url
-    callback_url(redirect_uri: request.env['referer'])
-  end
-
-  def signin
-    url = api.oauth_initiate_url({
-      client_id: PrismicService.config("client_id"),
-      redirect_uri: get_callback_url,
-      scope: "master+releases"
-    })
-    redirect_to url
-  end
-
-  def callback
-    access_token = api.oauth_check_token({
-      grant_type: "authorization_code",
-      code: params[:code],
-      redirect_uri: get_callback_url,
-      client_id: PrismicService.config("client_id"),
-      client_secret: PrismicService.config("client_secret"),
-    })
-    if access_token
-      session['ACCESS_TOKEN'] = access_token
-      url = params['redirect_uri'] || root_path
-      redirect_to url
-    else
-      render "Can't sign you in", status: :unauthorized
-    end
-  end
-
-  def signout
-    session['ACCESS_TOKEN'] = nil
-    redirect_to :root
-  end
+  
 
   private
 

--- a/app/controllers/prismic_oauth_controller.rb
+++ b/app/controllers/prismic_oauth_controller.rb
@@ -1,0 +1,41 @@
+# The necessary actions to have prismic.io OAuth2 connection working.
+# This allows to access to the master ref on private APIs, and to access to the future content releases.
+# If you need to change your client id and client secret, it happens in the config/prismic.yml file.
+class PrismicOauthController < ApplicationController
+	
+  def get_callback_url
+    callback_url(redirect_uri: request.env['referer'])
+  end
+
+  def signin
+    url = api.oauth_initiate_url({
+      client_id: PrismicService.config("client_id"),
+      redirect_uri: get_callback_url,
+      scope: "master+releases"
+    })
+    redirect_to url
+  end
+
+  def callback
+    access_token = api.oauth_check_token({
+      grant_type: "authorization_code",
+      code: params[:code],
+      redirect_uri: get_callback_url,
+      client_id: PrismicService.config("client_id"),
+      client_secret: PrismicService.config("client_secret"),
+    })
+    if access_token
+      session['ACCESS_TOKEN'] = access_token
+      url = params['redirect_uri'] || root_path
+      redirect_to url
+    else
+      render "Can't sign you in", status: :unauthorized
+    end
+  end
+
+  def signout
+    session['ACCESS_TOKEN'] = nil
+    redirect_to :root
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,11 +64,8 @@ StarterRubyRails::Application.routes.draw do
   # # Basic search
   get '/search', to: 'application#search', as: :search
 
-  # # Prismic.io OAuth
-  # GET     /signin                                     controllers.Prismic.signin
-  # GET     /auth_callback                              controllers.Prismic.callback(code: Option[String], redirect_uri: Option[String])
-  # POST    /signout                                    controllers.Prismic.signout()
-  get '/signin', to: 'application#signin', as: :signin
-  get '/callback', to: 'application#callback', as: :callback
-  get '/signout', to: 'application#signout', as: :signout
+  # # Prismic.io OAuth - you shouldn't touch those lightly, if you need OAuth2 to keep working with prismic.io
+  get '/signin', to: 'prismic_oauth#signin', as: :signin
+  get '/callback', to: 'prismic_oauth#callback', as: :callback
+  get '/signout', to: 'prismic_oauth#signout', as: :signout
 end


### PR DESCRIPTION
I'm not sure about best practice on how to segment controllers, but these actions hanging out in the same controller where work is supposed to get done are just really annoying, and make the controller harder to maintain for no reason.
Does it sound ok on a "controller best practice" point of view to make them live their own lives in their own controller?
