### PR TITLE
Factorisation of prismic-specific controller methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ There are several places where you'll be able to find helpful helpers of many ki
    * "document" pages display a whole document in a trivial way.
    * "search" pages are search results.
    * in `app/views/layouts/application.html.erb`, all those pages contain the necessary UI components to have the OAuth working out of the box: signing in, signing out, changing content releases, ... Of course, you can customize those UI components.
+ * in `app/controllers/prismic_oauth_controller.rb`: actions used to login/logout of OAuth, and their proper configuration in `routes.rb`.
  * in `app/helpers/prismic_helper.rb`:
    * provides a basic `link_resolver(ref)` method. For a given document, the `link_resolver` method describes its URL on your front-office. You really should edit this method, so that it supports all the document types your content writers might link to.
    * provides `api`, `ref` and `maybe_ref` method, just like in `PrismicController`, to use those in the views.

--- a/app/controllers/prismic_controller.rb
+++ b/app/controllers/prismic_controller.rb
@@ -1,41 +1,5 @@
 # The necessary methods your controller needs to use prismic.io transparently
 module PrismicController
-	
-  def get_callback_url
-    callback_url(redirect_uri: request.env['referer'])
-  end
-
-  def signin
-    url = PrismicService.oauth_initiate_url(access_token,
-      client_id: PrismicService.config("client_id"),
-      redirect_uri: get_callback_url,
-      scope: "master+releases"
-    )
-    redirect_to url
-  end
-
-  def callback
-    token = PrismicService.oauth_check_token(access_token,
-      grant_type: "authorization_code",
-      code: params[:code],
-      redirect_uri: get_callback_url,
-      client_id: PrismicService.config("client_id"),
-      client_secret: PrismicService.config("client_secret"),
-    )
-    if token
-      session['ACCESS_TOKEN'] = token
-      url = params['redirect_uri'] || root_path
-      redirect_to url
-    else
-      render "Can't sign you in", status: :unauthorized
-    end
-  end
-
-  def signout
-    session['ACCESS_TOKEN'] = nil
-    redirect_to :root
-  end
-
 
   private
 

--- a/app/controllers/prismic_oauth_controller.rb
+++ b/app/controllers/prismic_oauth_controller.rb
@@ -1,0 +1,41 @@
+class PrismicOauthController < ActionController::Base
+  include PrismicController
+
+  def signin
+    url = PrismicService.oauth_initiate_url(access_token,
+      client_id: PrismicService.config("client_id"),
+      redirect_uri: get_callback_url,
+      scope: "master+releases"
+    )
+    redirect_to url
+  end
+
+  def callback
+    token = PrismicService.oauth_check_token(access_token,
+      grant_type: "authorization_code",
+      code: params[:code],
+      redirect_uri: get_callback_url,
+      client_id: PrismicService.config("client_id"),
+      client_secret: PrismicService.config("client_secret"),
+    )
+    if token
+      session['ACCESS_TOKEN'] = token
+      url = params['redirect_uri'] || root_path
+      redirect_to url
+    else
+      render "Can't sign you in", status: :unauthorized
+    end
+  end
+
+  def signout
+    session['ACCESS_TOKEN'] = nil
+    redirect_to :root
+  end
+
+  private
+
+  def get_callback_url
+    callback_url(redirect_uri: request.env['referer'])
+  end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,7 +65,7 @@ StarterRubyRails::Application.routes.draw do
   get '/search', to: 'application#search', as: :search
 
   # # Prismic.io OAuth - you shouldn't touch those lightly, if you need OAuth2 to keep working with prismic.io
-  get '/signin', to: 'application#signin', as: :signin
-  get '/callback', to: 'application#callback', as: :callback
-  get '/signout', to: 'application#signout', as: :signout
+  get '/signin', to: 'prismic_oauth#signin', as: :signin
+  get '/callback', to: 'prismic_oauth#callback', as: :callback
+  get '/signout', to: 'prismic_oauth#signout', as: :signout
 end


### PR DESCRIPTION
I just put everything in a new `PrismicController` (what was in `PrismicOauthController` and the common part that was always in `ApplicationController`), and now, if you wish your `ApplicationController` actions to be able to use prismic.io, you simply need to have it extend `PrismicController`.

@dohzya, does it sound good to you?

If so, I'll generalize it to other examples we have, and then I'll make a generator for it and for the `PrismicService` and all, in the gem, if you agree it's a good idea.
