### PR TITLE
Linked documents + PrismicService.getDocuments

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -28,6 +28,9 @@ class ApplicationController < ActionController::Base
     if !@slug_checker[:correct]
       render inline: "Document not found", status: :not_found if !@slug_checker[:redirect]
       redirect_to document_path(id, @document.slug), status: :moved_permanently if @slug_checker[:redirect]
+    else
+      # Since I want to list linked documents, I'm querying them right away
+      @linked_documents = PrismicService.get_documents(@document.linked_documents.map(&:id), api, ref) if !@document.linked_documents.blank?
     end
   end
 

--- a/app/models/prismic_service.rb
+++ b/app/models/prismic_service.rb
@@ -37,6 +37,19 @@ module PrismicService
       documents.length == 0 ? nil : documents.first
     end
 
+    # Gets a list of documents, from an array of their IDs, in the right order
+    # Returns an array of Document objects
+    # This is more performant than querying for each document, as it does only one query
+    def get_documents(ids, api, ref)
+      ids_as_string = ids.map{|id| "\"#{id}\""}.join(', ')
+      documents = api.form("everything")
+                     .query("[[:d = any(document.id, ["+ids_as_string+"])]]")
+                     .submit(ref)
+      # Reordering the documents in the original order of IDs
+      documents_by_id = documents.results.index_by{|document| document.id}
+      ids.map{|id| documents_by_id[id] }
+    end
+
     # Checks if the slug is the right one for the document.
     # You can change this depending on your URL strategy.
     def slug_checker(document, slug)

--- a/app/views/application/document.html.erb
+++ b/app/views/application/document.html.erb
@@ -5,3 +5,16 @@
 	%>
 	<%= @document.as_html_safe(link_resolver(maybe_ref)) %>
 </article>
+
+
+<% if @linked_documents %>
+	<hr>
+	<aside>
+		<h2>Linked documents:</h2>
+		<ul>
+			<% @linked_documents.each do |linked_document| %>
+				<li><%= link_to linked_document.first_title || "Untitled document", link_resolver(maybe_ref).link_to(linked_document) %></li>
+			<% end %>
+		</ul>
+	</aside>
+<% end %>


### PR DESCRIPTION
Making good use of the brand new linked documents exposed in the API, and listing them in the "document" page.

I used the occasion to also create a `PrismicService.getDocuments` method, which exists in some other starter projects (like the Node.js one).

**Careful: do not merge this as long as the linked documents feature is not live in all repository APIs!**
